### PR TITLE
Fixed name of the field, should be accommodates

### DIFF
--- a/examples/MongoDB/BeyondTheBasics/expressiveQuery/expressiveQuery.js
+++ b/examples/MongoDB/BeyondTheBasics/expressiveQuery/expressiveQuery.js
@@ -16,7 +16,7 @@ async function get_Query(req, res) {
     "address.country": 1,
     "address.market": 1,
     beds: 1,
-    accomodates: 1,
+    accommodates: 1,
     price: 1,
     cleaning_fee: 1,
     guests_included: 1,


### PR DESCRIPTION
It doesn't show in the projection in https://edee.mongodb.com/index.html?src=MongoDB_BeyondTheBasics_expressiveQuery as it's spelled with just one "m"