### PR TITLE
Added charset to avoid emojis showing up as garbage characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
     <script src="appconfig.js"></script>
     <script src="//ajaxorg.github.io/ace-builds/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="https://unpkg.com/realm-web/dist/bundle.iife.js"></script>


### PR DESCRIPTION
Without that buttons looked like:

![Screenshot 2024-06-18 at 11 56 40](https://github.com/mongodb-developer/EDEE_Frontend_Development/assets/1008174/a5259e6c-a78b-4c4f-b391-99398c4b1675)
