### PR TITLE
Revisions to Index Speed example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ lerna-debug.log
 # System Files
 .DS_Store
 Thumbs.db
+appconfig.js

--- a/appconfig.js
+++ b/appconfig.js
@@ -1,2 +1,2 @@
-__hostingsite = "andrewslaptop"
-__atlasappid = "edee_production-szmvu"
+__hostingsite = "gcr_edee_dev"
+__atlasappid = "gcr_edee_dev-rhnsbxk"

--- a/driver.js
+++ b/driver.js
@@ -774,7 +774,7 @@ class MongoCollection {
    * @returns number of matching documents
    */
 
-  async countDocuments(query) {
+  async countDocuments(query, extended) {
     if (!(await this.mongoClient.connect()))
       throw new Error(this.mongoClient.lastError);
     if(!query) { query = {}; }
@@ -784,7 +784,12 @@ class MongoCollection {
       this.collName,
       query
     );
-    return rval;
+    //The if statement handles callers looking for the extended results (including execution time)
+    if(extended){
+      return rval;
+    }else{
+      return rval.message;
+    }
   }
 }
 

--- a/driver.js
+++ b/driver.js
@@ -784,7 +784,7 @@ class MongoCollection {
       this.collName,
       query
     );
-    return rval.result;
+    return rval;
   }
 }
 

--- a/examples/MongoDB/Lab2/indexSpeed/description.txt
+++ b/examples/MongoDB/Lab2/indexSpeed/description.txt
@@ -1,17 +1,15 @@
 This runs two queries on the same large data set.
 
-One has an index that can be used, and the other does not. They return
+One has an index that can be used, and the other does not, they return
 almost the same number of documents.
 
-It uses find().explain() with the 'executionStats' option, rather than
-find(). This will cause MongoDB to select an execution plan, run the
-winning plan, and include execution metrics from the return, including
-the execution time and number of documents returned. The explain
-metrics exclude any network overhead.
+It uses countDocuments() rather than find() which performs the find
+but only returns the count from the server. This excludes the network
+cost of fetching a lot of documents over the network from the
+measurement.
 
-After an initial call to the webservice, which may may be slower due
-to data not being loaded from disk to in-memory cache, an indexed query 
-will be a fairly constant speed.
+An indexed query will be a fairly constant speed, though
+you'll also see some significant network overhead in these results.
 
 A collection scan (no index) will place a lot of load on the server,
 proportaional to the number of callers so it may be very slow in a 

--- a/examples/MongoDB/Lab2/indexSpeed/indexSpeed.js
+++ b/examples/MongoDB/Lab2/indexSpeed/indexSpeed.js
@@ -12,14 +12,14 @@ async function get_IndexDemo(req, res) {
     var projection = { _id: 1 };
     var rval = msg;
 
-    result = await collection.countDocuments(query);
+    result = await collection.countDocuments(query, true);
 
     rval += "Query " + JSON.stringify(query) + " with index took approx " +
         result.ms + " ms to find " + result.message + " records\n";
 
     query = { bedrooms: 8 };
 
-    result = await collection.countDocuments(query);
+    result = await collection.countDocuments(query, true);
 
     rval += "Query " + JSON.stringify(query) + " with NO index took approx " +
         result.ms + " ms to find " + result.message + " records\n";

--- a/examples/MongoDB/Lab2/indexSpeed/indexSpeed.js
+++ b/examples/MongoDB/Lab2/indexSpeed/indexSpeed.js
@@ -1,38 +1,34 @@
 var mongoClient = null;
 var collection, msg;
 
-/* In this collection, the field containing the total number of
-   beds in the property is indexed, while the number of bedrooms
-   is not.
-   
-   You can only use an index if the first field in the index is in
+/* This collection has indexes on property_type, room_type, and beds.
+   But, you can only use an index if the first field in the index is in
    the query */
+
 
 async function get_IndexDemo(req, res) {
 
+    var query = { beds: 11 };
+    var projection = { _id: 1 };
     var rval = msg;
 
-    //Get execution time and number of results with index
-    var query = { beds: 11 };
-    result = await collection.find(query).explain('executionStats');
-    var indexTime = result.executionStats.executionTimeMillis;
-    indexTime = (indexTime === 0) ? 1 : indexTime;
-    rval += "Query " + JSON.stringify(query) +  " with index took " + 
-        indexTime + " ms to find " + result.executionStats.nReturned + " records\n";
-    
-    //Get execution time and number of results without index
-    query = { bedrooms: 8 };
-    result = await collection.find(query).explain('executionStats');
-    var nonIndexTime = result.executionStats.executionTimeMillis
-    nonIndexTime = (nonIndexTime === 0) ? 1 : nonIndexTime;
-    rval += "Query " + JSON.stringify(query) + " with NO index took approx " + 
-        nonIndexTime + " ms to find " + result.executionStats.nReturned + " records\n";
+    result = await collection.countDocuments(query);
 
-    rval += "\nTimes do NOT include server roundtrip time.";
-       
+    rval += "Query " + JSON.stringify(query) + " with index took approx " +
+        result.ms + " ms to find " + result.message + " records\n";
+
+    query = { bedrooms: 8 };
+
+    result = await collection.countDocuments(query);
+
+    rval += "Query " + JSON.stringify(query) + " with NO index took approx " +
+        result.ms + " ms to find " + result.message + " records\n";
+
     res.header("Content-Type", "text/plain");
+    //res.header("Server-ping-time", mongoClient.getPingTime() + "ms (approx.)");
+
     res.send(rval);
-   
+
 }
 
 async function initWebService() {

--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ async function callService(method) {
     const endTime = Date.now();
 
 
-    let timeToShow = Math.floor((endTime - startTime) - (MongoClient._serverLatency * MongoClient._nServerCalls));
+    let timeToShow = Math.floor((endTime - startTime)); //- (MongoClient._serverLatency * MongoClient._nServerCalls));
     if (timeToShow < 1) timeToShow = 1;
 
     let renderOut = "";


### PR DESCRIPTION
Revisions revert Index Speed to use countDocuments rather than explain plan. The execution time is returned from the corresponding App Service function. 

A new parameter to countDocuments allows caller to specify if they want results in the revised format, or just the document count as was sent before. Absence of the parameter in the call is assumed to mean the later.